### PR TITLE
[BUGFIX] Fix wrong xmlns

### DIFF
--- a/Resources/Private/Templates/Subscribe/ShowForm.html
+++ b/Resources/Private/Templates/Subscribe/ShowForm.html
@@ -1,5 +1,5 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:ns="Zwo3\NewsletterSubscribe\ViewHelpers"
+      xmlns:ns="http://typo3.org/ns/Zwo3/NewsletterSubscribe/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
 <f:layout name="Standard"></f:layout>


### PR DESCRIPTION
This change fixes the ViewHelper support in PhpStorm according to the [core documentation](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/7.3/Feature-66269-FluidRemoveViewHelperXmlnsAttributesAndSpecifiedHtmlTag.html#impact).