### PR TITLE
Console Command to fill subscription_hash

### DIFF
--- a/Classes/Command/FillsubscriptionhashCommand.php
+++ b/Classes/Command/FillsubscriptionhashCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Zwo3\NewsletterSubscribe\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class FillsubscriptionhashCommand extends Command
+{   
+    /**
+     * @var ConfigurationManagerInterface
+     */
+    protected $configurationManager;
+
+    /**
+     * Injects the Configuration Manager and is initializing the framework settings
+     *
+     * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager Instance of the Configuration Manager
+     */
+    public function injectConfigurationManager(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager) {
+        $this->configurationManager = $configurationManager;
+    }
+
+    /**
+     * Configure the command by defining the name, options and arguments
+     */
+    protected function configure()
+    {
+
+    }
+    
+    /**
+     * Executes the command to fill subscription hash field
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int error code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+
+        $counter = 0;
+        $table = 'tt_address';
+        $io = new SymfonyStyle($input, $output);
+        $io->title($this->getDescription());
+        
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->select('uid', 'pid', 'email', 'crdate', 'tstamp')
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, \PDO::PARAM_INT))  
+             )
+              ->andWhere(
+                  $queryBuilder->expr()->orX(
+                      $queryBuilder->expr()->eq('subscription_hash', '\'\''),
+                      $queryBuilder->expr()->isNull('subscription_hash')
+                  )
+              )
+             ->orderBy('uid', 'asc');
+        $rowIterator = $queryBuilder->execute();
+        
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable($table);
+        
+        while ($row = $rowIterator->fetch()) {
+            $subscriptionHash = hash('sha256', $row['email'] . $row['crdate'] ?: $row['tstamp'] . random_bytes(32));
+            $queryBuilder
+                ->update($table)
+                ->where(
+                    $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($row['uid'], \PDO::PARAM_INT))
+                )
+                ->set('subscription_hash', $subscriptionHash)
+                ->execute();
+            $counter++;
+        }
+        
+        $io->writeln('Changed: '.$counter);
+        return 0;
+    }
+}

--- a/Classes/Command/FillsubscriptionhashCommand.php
+++ b/Classes/Command/FillsubscriptionhashCommand.php
@@ -13,28 +13,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class FillsubscriptionhashCommand extends Command
 {   
     /**
-     * @var ConfigurationManagerInterface
-     */
-    protected $configurationManager;
-
-    /**
-     * Injects the Configuration Manager and is initializing the framework settings
-     *
-     * @param \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager Instance of the Configuration Manager
-     */
-    public function injectConfigurationManager(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface $configurationManager) {
-        $this->configurationManager = $configurationManager;
-    }
-
-    /**
-     * Configure the command by defining the name, options and arguments
-     */
-    protected function configure()
-    {
-
-    }
-    
-    /**
      * Executes the command to fill subscription hash field
      *
      * @param InputInterface $input
@@ -43,8 +21,6 @@ class FillsubscriptionhashCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-
-
         $counter = 0;
         $table = 'tt_address';
         $io = new SymfonyStyle($input, $output);

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,12 +6,15 @@ services:
 
   Zwo3\NewsletterSubscribe\:
     resource: '../Classes/*'
-    
+
   Zwo3\NewsletterSubscribe\Command\FillsalutationCommand:
     tags:
       - name: 'console.command'
         command: 'newslettersubscribe:fillsalutation'
         description: 'Fill salutation field in tt_address'
-        # not required, defaults to false
-        #hidden: false
-        #schedulable: false
+
+  Zwo3\NewsletterSubscribe\Command\FillsubscriptionhashCommand:
+    tags:
+      - name: 'console.command'
+        command: 'newslettersubscribe:fillsubscriptionhash'
+        description: 'Fill subscription hash field in tt_address'

--- a/README.md
+++ b/README.md
@@ -165,12 +165,21 @@ routeEnhancers:
           unsubscribe: subscriptionHash
           uid: uid
 ```
-## Unsubscribe link in direkt mail
+## Unsubscribe link in direct_mail
 1. First add the field subscription_hash to the fields of direct mail in the extension configuration of direct mail: 
 ![direct mail configuration](https://github.com/Gregor-Agnes/newsletter_subscribe/raw/master/Resources/Public/Gfx/ExtManDirectMail1.png)
 2. Add the link in your mail template:\
 `<a href="http://www.domain.tld/page/undosubscribe/###USER_subscription_hash###/###USER_uid###">unsubscribe</a>`
 where this `undosubscribe/###USER_subscription_hash###/###USER_uid###"` is the important part.<br>Note: The subscribe plugin must be inserted on the page "page" in that url.
+
+## Scheduler Tasks / Console Commands
+
+There are scheduler tasks / console commands available (TYPO3 v10 only) to fill empty database fields in `tt_address`:
+
+- `newslettersubscribe:fillsalutation`  
+  Updates the salutation field based on the sys_language_uid and gender fields of the tt_address records. The salutation can be configured via TypoScript.
+- `newslettersubscribe:fillsubscriptionhash`  
+  Updates the subscription_hash field. This is especially handy if there are subscriptions added manually in the TYPO3 backend or you have legacy data in tt_address. The subscription_hash is necessary for the unsubscribe link in direct_mail to work.
 
 ***
 


### PR DESCRIPTION
This pull requests adds a new feature to update the subscription_hash field in tt_address. This is especially handy if there are subscriptions added manually in the TYPO3 backend or you have legacy data in tt_address.

Due to legacy reasons I calculate the hash with either crdate or tstamp.

Furthermore this patch adds a little bit of documentation about the scheduler tasks / console commands.

I have created this patch analogous to the already existing command. Since `Services.yaml` is used for the registration, the commands need TYPO3 v10 to work.