### PR TITLE
[BUGFIX] Fix wrong default value for hit_number in TCA

### DIFF
--- a/Configuration/TCA/Overrides/tt_address.php
+++ b/Configuration/TCA/Overrides/tt_address.php
@@ -38,7 +38,7 @@ $tempColumns = [
         'config' => [
             'size' => 30,
             'type' => 'input',
-            'default' => '',
+            'default' => 0,
             'readOnly' => 1
         ],
     ],


### PR DESCRIPTION
This patch mitigates a problem when creating a new tt_address record in the backend:

`SQL error: 'Incorrect integer value: '' for column db.tt_address.hit_number at row 1'`