### PR TITLE
[BUGFIX] The setting "mailLayoutRootPath" is only used for mails to t…

### DIFF
--- a/Classes/Controller/SubscribeController.php
+++ b/Classes/Controller/SubscribeController.php
@@ -503,8 +503,8 @@ class SubscribeController extends ActionController
             $templatePaths->setTemplateRootPaths(
                 [GeneralUtility::getFileAbsFileName($this->settings['mailTemplateRootPath'] . $twoLetterIsoCode .'/')]
             );
-            $templatePaths->setLayoutRootPaths([$this->settings['mailLayoutRootPath'] .'/']);
         }
+        $templatePaths->setLayoutRootPaths([$this->settings['mailLayoutRootPath'] .'/']);
 
         /** @var FluidEmail $email */
         $email = GeneralUtility::makeInstance(FluidEmail::class, $templatePaths);


### PR DESCRIPTION
…he users.

This patch uses the "mailLayoutRootPath" setting regardless of the recipient type (user or admin)