### PR TITLE
fix access to `ContentObjectRenderer` (#103)

### DIFF
--- a/Classes/Controller/SubscribeController.php
+++ b/Classes/Controller/SubscribeController.php
@@ -105,7 +105,10 @@ class SubscribeController extends ActionController
      */
     public function initializeView(\TYPO3Fluid\Fluid\View\ViewInterface $view): void
     {
-        $contentObject = $this->configurationManager->getContentObject();
+        /**
+         * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObject
+         */
+        $contentObject = $this->request->getAttribute('currentContentObject');
         if ($contentObject && isset($contentObject->data['uid'])) {
             $view->assign('uid', $contentObject->data['uid']);
         } else {
@@ -135,9 +138,14 @@ class SubscribeController extends ActionController
             $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
             $typoScriptArray = $typoScriptService->convertPlainArrayToTypoScriptArray($originalSettings);
             $stdWrapProperties = GeneralUtility::trimExplode(',', $originalSettings['useStdWrap'], true);
+
+            /**
+             * @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObject
+             */
+            $contentObject = $this->request->getAttribute('currentContentObject');
             foreach ($stdWrapProperties as $key) {
                 if (is_array($typoScriptArray[$key . '.'])) {
-                    $originalSettings[$key] = $this->configurationManager->getContentObject()
+                    $originalSettings[$key] = $contentObject
                         ->stdWrap(
                             $typoScriptArray[$key],
                             $typoScriptArray[$key . '.']


### PR DESCRIPTION
Replace the call to `$this->configurationManager->getContentObject()` with `$this->request->getAttribute('currentContentObject')` and provide a type-hint for the variable.

⚠️ I did test the normal flow, but I did not check the `useStdWrap` feature.